### PR TITLE
Fix forest creation by database

### DIFF
--- a/marklogic/models/database.py
+++ b/marklogic/models/database.py
@@ -144,7 +144,7 @@ class Database:
         :param forests: A list of forest names
         :return:The database object
         """
-        self.config[u'forest'] = forests
+        self.config['forest'] = forests
         return self
 
     def add_forest(self, forest):
@@ -155,20 +155,20 @@ class Database:
         :param forest: The forest name
         :return: The database object
         """
-        if not self.config[u'forest']:
-            self.config[u'forest'] = []
+        if not self.config['forest']:
+            self.config['forest'] = []
 
-        self.config[u'forest'].append(forest)
+        self.config['forest'].append(forest)
 
         return self
 
     def forests(self):
         """
-        Return the forests associated with this database
+        Return the names of the forests associated with this database
 
         :return: The associated forests
         """
-        return self.config[u'forest']
+        return self.config['forest']
 
     def set_language(self, language):
         """
@@ -178,7 +178,7 @@ class Database:
         :param language: The language abbreviation
         :return: The database object
         """
-        self.config[u'language'] = language
+        self.config['language'] = language
         return self
 
     def language(self):
@@ -187,9 +187,9 @@ class Database:
 
         :return: The default language for the database.
         """
-        return self.config[u'language']
+        return self.config['language']
 
-    def set_stemmed_searches(self, which=u'basic'):
+    def set_stemmed_searches(self, which='basic'):
         """
         Set the stemmed search option for the database.  Valid values are 'off',
         'basic', 'advanced' and 'decompounding'.
@@ -198,7 +198,7 @@ class Database:
         :return: The database object
         """
         validate_stemmed_searches_type(which)
-        self.config[u'stemmed-searches'] = which
+        self.config['stemmed-searches'] = which
         return self
 
     def stemmed_searches(self):
@@ -207,7 +207,7 @@ class Database:
 
         :return: The type of stemmed search
         """
-        return self.config[u'stemmed-searches']
+        return self.config['stemmed-searches']
 
     def set_word_searches(self, enabled=False):
         """
@@ -217,7 +217,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'word-searches'] = enabled
+        self.config['word-searches'] = enabled
         return self
 
     def word_searches(self):
@@ -226,7 +226,7 @@ class Database:
 
         :return: Stemmed word searches enabled
         """
-        return self.config[u'word-searches']
+        return self.config['word-searches']
 
     def set_word_positions(self, enabled=False):
         """
@@ -236,7 +236,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'word-positions'] = enabled
+        self.config['word-positions'] = enabled
         return self
 
     def word_positions(self):
@@ -245,7 +245,7 @@ class Database:
 
         :return: Word positions are enabled
         """
-        return self.config[u'word-positions']
+        return self.config['word-positions']
 
     def set_fast_phrase_searches(self, enabled=True):
         """
@@ -255,7 +255,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-phrase-searches'] = enabled
+        self.config['fast-phrase-searches'] = enabled
         return self
 
     def fast_phrase_searches(self):
@@ -264,7 +264,7 @@ class Database:
 
         :return: Fast phrase searches enabled
         """
-        return self.config[u'fast-phrase-searches']
+        return self.config['fast-phrase-searches']
 
     def set_fast_reverse_searches(self, enabled=True):
         """
@@ -274,7 +274,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-reverse-searches'] = enabled
+        self.config['fast-reverse-searches'] = enabled
         return self
 
     def fast_reverse_searches(self):
@@ -283,7 +283,7 @@ class Database:
 
         :return: Fast reverse searches enabled
         """
-        return self.config[u'fast-reverse-searches']
+        return self.config['fast-reverse-searches']
 
     def set_triple_index(self, enabled=False):
         """
@@ -293,7 +293,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'triple-index'] = enabled
+        self.config['triple-index'] = enabled
         return self
 
     def triple_index(self):
@@ -302,7 +302,7 @@ class Database:
 
         :return: The triple index enabled
         """
-        return self.config[u'triple-index']
+        return self.config['triple-index']
 
     def set_triple_positions(self, enabled=False):
         """
@@ -312,7 +312,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'triple-positions'] = enabled
+        self.config['triple-positions'] = enabled
         return self
 
     def triple_positions(self):
@@ -321,7 +321,7 @@ class Database:
 
         :return: Triple positions enabled
         """
-        return self.config[u'triple-positions']
+        return self.config['triple-positions']
 
     def set_fast_case_senstive_searches(self, enabled=True):
         """
@@ -331,7 +331,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-case-sensitive-searches'] = enabled
+        self.config['fast-case-sensitive-searches'] = enabled
         return self
 
     def fast_cast_sensitive_searches(self):
@@ -340,7 +340,7 @@ class Database:
 
         :return: Fast case sensitive searches enabled
         """
-        return self.config[u'fast-case-sensitive-searches']
+        return self.config['fast-case-sensitive-searches']
 
     def set_fast_diacritic_sensitive_searches(self, enabled=True):
         """
@@ -350,7 +350,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-diacritic-sensitive-searches'] = enabled
+        self.config['fast-diacritic-sensitive-searches'] = enabled
         return self
 
     def fast_diacritic_sensitive_searches(self):
@@ -359,7 +359,7 @@ class Database:
 
         :return: Fast diacritic sensitive searches enabled
         """
-        return self.config[u'fast-diacritic-sensitive-searches']
+        return self.config['fast-diacritic-sensitive-searches']
 
     def set_fast_element_word_searches(self, enabled=True):
         """
@@ -369,7 +369,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-element-word-searches'] = enabled
+        self.config['fast-element-word-searches'] = enabled
         return self
 
     def fast_element_word_searches(self):
@@ -378,7 +378,7 @@ class Database:
 
         :return: Fast element word searches enabled
         """
-        return self.config[u'fast-element-word-searches']
+        return self.config['fast-element-word-searches']
 
     def set_element_word_positions(self, enabled=False):
         """
@@ -388,7 +388,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'element-word-positions'] = enabled
+        self.config['element-word-positions'] = enabled
         return self
 
     def element_word_positions(self):
@@ -397,7 +397,7 @@ class Database:
 
         :return: Fast element word searches enabled
         """
-        return self.config[u'element-word-positions']
+        return self.config['element-word-positions']
 
     def set_fast_element_phrase_searches(self, enabled=True):
         """
@@ -407,7 +407,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-element-phrase-searches'] = enabled
+        self.config['fast-element-phrase-searches'] = enabled
         return self
 
     def fast_element_phrase_searches(self):
@@ -416,7 +416,7 @@ class Database:
 
         :return: Fast element phrase searches enabled
         """
-        return self.config[u'fast-element-phrase-searches']
+        return self.config['fast-element-phrase-searches']
 
     def set_element_value_positions(self, enabled=False):
         """
@@ -426,7 +426,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'element-value-positions'] = enabled
+        self.config['element-value-positions'] = enabled
         return self
 
     def element_value_positions(self):
@@ -435,7 +435,7 @@ class Database:
 
         :return: Element value positions enabled
         """
-        return self.config[u'element-value-positions']
+        return self.config['element-value-positions']
 
     def set_attribute_value_positions(self, enabled=False):
         """
@@ -445,7 +445,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'attribute-value-positions'] = enabled
+        self.config['attribute-value-positions'] = enabled
         return self
 
     def attribute_value_positions(self):
@@ -454,7 +454,7 @@ class Database:
 
         :return: Attribute value positions enabled
         """
-        return self.config[u'attribute-value-positions']
+        return self.config['attribute-value-positions']
 
     def set_field_value_searches(self, enabled=False):
         """
@@ -464,7 +464,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'field-value-searches'] = enabled
+        self.config['field-value-searches'] = enabled
         return self
 
     def field_value_searches(self):
@@ -473,7 +473,7 @@ class Database:
 
         :return: Field value searches enabled
         """
-        return self.config[u'field-value-searches']
+        return self.config['field-value-searches']
 
     def set_field_value_positions(self, enabled=False):
         """
@@ -483,7 +483,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'field-value-positions'] = enabled
+        self.config['field-value-positions'] = enabled
         return self
 
     def field_value_positions(self):
@@ -492,7 +492,7 @@ class Database:
 
         :return: Field value positions enabled
         """
-        return self.config[u'field-value-positions']
+        return self.config['field-value-positions']
 
     def set_three_character_searches(self, enabled=False):
         """
@@ -502,7 +502,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'three-character-searches'] = enabled
+        self.config['three-character-searches'] = enabled
         return self
 
     def three_character_searches(self):
@@ -511,7 +511,7 @@ class Database:
 
         :return: Three character searches enabled
         """
-        return self.config[u'three-character-searches']
+        return self.config['three-character-searches']
 
     def set_three_character_word_positions(self, enabled=False):
         """
@@ -521,7 +521,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'three-character-word-positions'] = enabled
+        self.config['three-character-word-positions'] = enabled
         return self
 
     def three_character_word_positions(self):
@@ -530,7 +530,7 @@ class Database:
 
         :return: Three character word positions enabled
         """
-        return self.config[u'three-character-word-positions']
+        return self.config['three-character-word-positions']
 
     def set_fast_element_character_searches(self, enabled=False):
         """
@@ -540,7 +540,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-element-character-searches'] = enabled
+        self.config['fast-element-character-searches'] = enabled
         return self
 
     def fast_element_character_searches(self):
@@ -549,7 +549,7 @@ class Database:
 
         :return: Fast element character searches
         """
-        return self.config[u'fast-element-character-searches']
+        return self.config['fast-element-character-searches']
 
     def set_trailing_wildcard_searches(self, enabled=False):
         """
@@ -559,7 +559,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'trailing-wildcard-searches'] = enabled
+        self.config['trailing-wildcard-searches'] = enabled
         return self
 
     def trailing_wildcard_searches(self):
@@ -568,7 +568,7 @@ class Database:
 
         :return: Trailing wild card searches enabled
         """
-        return self.config[u'trailing-wildcard-searches']
+        return self.config['trailing-wildcard-searches']
 
     def set_trailing_wildcard_word_positions(self, enabled=False):
         """
@@ -578,7 +578,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'trailing-wildcard-word-positions'] = enabled
+        self.config['trailing-wildcard-word-positions'] = enabled
         return self
 
     def trailing_wildcard_word_positions(self):
@@ -587,7 +587,7 @@ class Database:
 
         :return: Index word positions enabled
         """
-        return self.config[u'trailing-wildcard-word-positions']
+        return self.config['trailing-wildcard-word-positions']
 
     def set_fast_element_trailing_wildcard_searches(self, enabled=False):
         """
@@ -597,7 +597,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'fast-element-trailing-wildcard-searches'] = enabled
+        self.config['fast-element-trailing-wildcard-searches'] = enabled
         return self
 
     def fast_element_trailing_wildcard_searches(self):
@@ -606,7 +606,7 @@ class Database:
 
         :return: Fast element trailing wildcard searches enabled
         """
-        return self.config[u'fast-element-trailing-wildcard-searches']
+        return self.config['fast-element-trailing-wildcard-searches']
 
     def set_two_character_searches(self, enabled=False):
         """
@@ -616,7 +616,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'two-character-searches'] = enabled
+        self.config['two-character-searches'] = enabled
         return self
 
     def two_character_searches(self):
@@ -625,7 +625,7 @@ class Database:
 
         :return: Two character wildcard searches enabled
         """
-        return self.config[u'two-character-searches']
+        return self.config['two-character-searches']
 
     def set_one_character_searches(self, enabled=False):
         """
@@ -635,7 +635,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'one-character-searches'] = enabled
+        self.config['one-character-searches'] = enabled
         return self
 
     def one_character_searches(self):
@@ -644,7 +644,7 @@ class Database:
 
         :return: One character wildcard searches enabled
         """
-        return self.config[u'one-character-searches']
+        return self.config['one-character-searches']
 
     def set_uri_lexicon(self, enabled=True):
         """
@@ -654,7 +654,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'uri-lexicon'] = enabled
+        self.config['uri-lexicon'] = enabled
         return self
 
     def uri_lexicon(self):
@@ -663,7 +663,7 @@ class Database:
 
         :return: URI lexicon enabled
         """
-        return self.config[u'uri-lexicon']
+        return self.config['uri-lexicon']
 
     def set_collection_lexicon(self, enabled=False):
         """
@@ -673,7 +673,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'collection-lexicon'] = enabled
+        self.config['collection-lexicon'] = enabled
         return self
 
     def collection_lexicon(self):
@@ -682,7 +682,7 @@ class Database:
 
         :return: Collection lexicon enabled
         """
-        return self.config[u'collection-lexicon']
+        return self.config['collection-lexicon']
 
     def set_reindexer_enable(self, enabled=True):
         """
@@ -692,7 +692,7 @@ class Database:
         :return:
         """
         validate_boolean(enabled)
-        self.config[u'reindexer-enable'] = enabled
+        self.config['reindexer-enable'] = enabled
         return self
 
     def reindexer_enable(self):
@@ -701,7 +701,7 @@ class Database:
 
         :return: Automatic reindexing enabled
         """
-        return self.config[u'reindexer-enable']
+        return self.config['reindexer-enable']
 
     def set_reindexer_throttle(self, limit=5):
         """
@@ -711,7 +711,7 @@ class Database:
         :return: The database object
         """
         validate_integer_range(limit, 1, 5)
-        self.config[u'reindexer-throttle'] = limit
+        self.config['reindexer-throttle'] = limit
         return self
 
     def reindexer_throttle(self):
@@ -720,7 +720,7 @@ class Database:
 
         :return: The level of system resources
         """
-        return self.config[u'reindexer-throttle']
+        return self.config['reindexer-throttle']
 
     def set_reindexer_timestamp(self, limit=0):
         """
@@ -729,7 +729,7 @@ class Database:
         :param limit: Reindexer timestamp
         :return: The document object
         """
-        self.config[u'reindexer-timestamp'] = limit
+        self.config['reindexer-timestamp'] = limit
         return self
 
     def reindexer_timestamp(self):
@@ -738,9 +738,9 @@ class Database:
 
         :return: Reindexer timestamp in milliseconds
         """
-        return self.config[u'reindexer-timestamp']
+        return self.config['reindexer-timestamp']
 
-    def set_directory_creation(self, which=u'manual'):
+    def set_directory_creation(self, which='manual'):
         """
         Directory creation method
 
@@ -748,7 +748,7 @@ class Database:
         :return: The database object
         """
         validate_directory_creation(which)
-        self.config[u'directory-creation'] = which
+        self.config['directory-creation'] = which
         return self
 
     def directory_creation(self):
@@ -757,7 +757,7 @@ class Database:
 
         :return: Directory creation method
         """
-        return self.config[u'directory-creation']
+        return self.config['directory-creation']
 
     def set_maintain_last_modified(self, enabled=False):
         """
@@ -767,7 +767,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'maintain-last-modified'] = enabled
+        self.config['maintain-last-modified'] = enabled
         return self
 
     def maintain_last_modified(self):
@@ -776,7 +776,7 @@ class Database:
 
         :return: Maintain last modified
         """
-        return self.config[u'maintain-last-modified']
+        return self.config['maintain-last-modified']
 
     def set_maintain_directory_last_modified(self, enabled=False):
         """
@@ -786,7 +786,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'maintain-directory-last-modified'] = enabled
+        self.config['maintain-directory-last-modified'] = enabled
         return self
 
     def maintain_directory_last_modified(self):
@@ -795,7 +795,7 @@ class Database:
 
         :return: Maintain directory last modified property enabled
         """
-        return self.config[u'maintain-directory-last-modified']
+        return self.config['maintain-directory-last-modified']
 
     def set_inherit_permissions(self, enabled=False):
         """
@@ -805,7 +805,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'inherit-permissions'] = enabled
+        self.config['inherit-permissions'] = enabled
         return self
 
     def inherit_permissions(self):
@@ -814,7 +814,7 @@ class Database:
 
         :return: Inherit document permissions from parent enabled
         """
-        return self.config[u'inherit-permissions']
+        return self.config['inherit-permissions']
 
     def set_inherit_collections(self, enabled=False):
         """
@@ -824,7 +824,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'inherit-collections'] = enabled
+        self.config['inherit-collections'] = enabled
         return self
 
     def inherit_collections(self):
@@ -833,7 +833,7 @@ class Database:
 
         :return: Inherit default collections enabled
         """
-        return self.config[u'inherit-collections']
+        return self.config['inherit-collections']
 
     def set_inherit_quality(self, enabled=False):
         """
@@ -843,7 +843,7 @@ class Database:
         :return: The database object
         """
         validate_boolean(enabled)
-        self.config[u'inherit-quality'] = enabled
+        self.config['inherit-quality'] = enabled
         return self
 
     def inherit_quality(self):
@@ -852,7 +852,7 @@ class Database:
 
         :return: Inherity document quality
         """
-        return self.config[u'inherit-quality']
+        return self.config['inherit-quality']
 
     def set_in_memory_limit(self, limit=262144):
         """
@@ -861,7 +861,7 @@ class Database:
         :param limit: In memory fragment limit
         :return: The database object
         """
-        self.config[u'in-memory-limit'] = limit
+        self.config['in-memory-limit'] = limit
         return self
 
     def in_memory_limit(self):
@@ -870,7 +870,7 @@ class Database:
 
         :return: In memory fragment limit
         """
-        return self.config[u'in-memory-limit']
+        return self.config['in-memory-limit']
 
     def set_in_memory_list_size(self, limit=512):
         """
@@ -879,7 +879,7 @@ class Database:
         :param limit: The in memory list storage in megabytes
         :return: The database object
         """
-        self.config[u'in-memory-list-size'] = limit
+        self.config['in-memory-list-size'] = limit
         return self
 
     def in_memory_list_size(self):
@@ -888,7 +888,7 @@ class Database:
 
         :return: The in memory list storage size in megabytes
         """
-        return self.config[u'in-memory-list-size']
+        return self.config['in-memory-list-size']
 
     def set_in_memory_tree_size(self, limit=128):
         """
@@ -897,7 +897,7 @@ class Database:
         :param limit: In memory tree storage size
         :return: The database object
         """
-        self.config[u'in-memory-tree-size'] = limit
+        self.config['in-memory-tree-size'] = limit
         return self
 
     def in_memory_tree_size(self):
@@ -906,7 +906,7 @@ class Database:
 
         :return: In memory tree storage size
         """
-        return self.config[u'in-memory-tree-size']
+        return self.config['in-memory-tree-size']
 
     def set_in_memory_range_index_size(self, limit=16):
         """
@@ -915,7 +915,7 @@ class Database:
         :param limit: The in memory range index size
         :return: The database object
         """
-        self.config[u'in-memory-range-index-size'] = limit
+        self.config['in-memory-range-index-size'] = limit
         return self
 
     def in_memory_range_index_size(self):
@@ -924,7 +924,7 @@ class Database:
 
         :return: The in-memory range index size
         """
-        return self.config[u'in-memory-range-index-size']
+        return self.config['in-memory-range-index-size']
 
     def set_in_memory_reverse_index_size(self, limit=16):
         """
@@ -933,7 +933,7 @@ class Database:
         :param limit: In memory reverse index size
         :return: The database object
         """
-        self.config[u'in-memory-reverse-index-size'] = limit
+        self.config['in-memory-reverse-index-size'] = limit
         return self
 
     def in_memory_reverse_index_size(self):
@@ -942,7 +942,7 @@ class Database:
 
         :return: In memory reverse index size
         """
-        return self.config[u'in-memory-reverse-index-size']
+        return self.config['in-memory-reverse-index-size']
 
     def set_in_memory_triple_index_size(self, limit=64):
         """
@@ -951,7 +951,7 @@ class Database:
         :param limit: The in memory triple index size
         :return: The database object
         """
-        self.config[u'in-memory-triple-index-size'] = limit
+        self.config['in-memory-triple-index-size'] = limit
         return self
 
     def in_memory_triple_index_size(self):
@@ -960,7 +960,7 @@ class Database:
 
         :return: In memory triple index size
         """
-        return self.config[u'in-memory-triple-index-size']
+        return self.config['in-memory-triple-index-size']
 
     def set_large_size_threshold(self, limit=1024):
         """
@@ -969,7 +969,7 @@ class Database:
         :param limit: Size limit for large objects
         :return: The database object
         """
-        self.config[u'large-size-threshold'] = limit
+        self.config['large-size-threshold'] = limit
         return self
 
     def large_size_threshold(self):
@@ -978,9 +978,9 @@ class Database:
 
         :return: The large size threshold
         """
-        return self.config[u'large-size-threshold']
+        return self.config['large-size-threshold']
 
-    def set_locking(self, which=u'fast'):
+    def set_locking(self, which='fast'):
         """
         Specifies how robust transaction locking should be.
 
@@ -988,7 +988,7 @@ class Database:
         :return: The database object
         """
         validate_locking_type(which)
-        self.config[u'locking'] = which
+        self.config['locking'] = which
         return self
 
     def locking(self):
@@ -997,9 +997,9 @@ class Database:
 
         :return: The transaction locking
         """
-        return self.config[u'locking']
+        return self.config['locking']
 
-    def set_journaling(self, which=u'fast'):
+    def set_journaling(self, which='fast'):
         """
         Specifies how robust transaction journaling should be.
 
@@ -1007,7 +1007,7 @@ class Database:
         :return:The database object
         """
         validate_locking_type(which)
-        self.config[u'journaling'] = which
+        self.config['journaling'] = which
         return self
 
     def journaling(self):
@@ -1016,7 +1016,7 @@ class Database:
 
         :return:The journaling
         """
-        return self.config[u'journaling']
+        return self.config['journaling']
 
     def set_journal_size(self, limit=682):
         """
@@ -1025,7 +1025,7 @@ class Database:
         :param limit: The journal size
         :return:The database object
         """
-        self.config[u'journal-size'] = limit
+        self.config['journal-size'] = limit
         return self
 
     def journal_size(self):
@@ -1033,7 +1033,7 @@ class Database:
         The size of the journal, in megabytes.
         :return:The journal size
         """
-        return self.config[u'journal-size']
+        return self.config['journal-size']
 
     def set_journal_count(self, limit=2):
         """
@@ -1042,7 +1042,7 @@ class Database:
         :param limit:The journal count
         :return:The database object
         """
-        self.config[u'journal-count'] = limit
+        self.config['journal-count'] = limit
         return self
 
     def journal_count(self):
@@ -1051,7 +1051,7 @@ class Database:
 
         :return:The journal count
         """
-        return self.config[u'journal-count']
+        return self.config['journal-count']
 
     def set_preallocate_journal(self, enabled=False):
         """
@@ -1061,7 +1061,7 @@ class Database:
         :return:The database object
         """
         validate_boolean(enabled)
-        self.config[u'preallocate-journals'] = enabled
+        self.config['preallocate-journals'] = enabled
         return self
 
     def preallocate_journal(self):
@@ -1070,7 +1070,7 @@ class Database:
 
         :return:Pre-allocate journal files
         """
-        return self.config[u'preallocate-journals']
+        return self.config['preallocate-journals']
 
     def set_preload_mapped_data(self, enabled=False):
         """
@@ -1080,7 +1080,7 @@ class Database:
         :return:The database object
         """
         validate_boolean(enabled)
-        self.config[u'preload-mapped-data'] = enabled
+        self.config['preload-mapped-data'] = enabled
         return self
 
     def preload_mapped_data(self):
@@ -1089,7 +1089,7 @@ class Database:
 
         :return:Preload memory mapped forest information
         """
-        return self.config[u'preload-mapped-data']
+        return self.config['preload-mapped-data']
 
     def set_preload_replica_mapped_data(self, enabled=False):
         """
@@ -1099,7 +1099,7 @@ class Database:
         :return:The database object
         """
         validate_boolean(enabled)
-        self.config[u'preload-replica-mapped-data'] = enabled
+        self.config['preload-replica-mapped-data'] = enabled
         return self
 
     def preload_replica_mapped_data(self):
@@ -1108,9 +1108,9 @@ class Database:
 
         :return:Preload mapped replica forest information
         """
-        return self.config[u'preload-replica-mapped-data']
+        return self.config['preload-replica-mapped-data']
 
-    def set_range_index_optimize(self, which=u'facet-time'):
+    def set_range_index_optimize(self, which='facet-time'):
         """
         Specifies how to optimize range indexes
 
@@ -1118,7 +1118,7 @@ class Database:
         :return:The database object
         """
         validate_range_index_optimize_options(which)
-        self.config[u'range-index-optimize'] = which
+        self.config['range-index-optimize'] = which
         return self
 
     def range_index_optimize(self):
@@ -1127,7 +1127,7 @@ class Database:
 
         :return:Range index optimization type
         """
-        return self.config[u'range-index-optimize']
+        return self.config['range-index-optimize']
 
     def set_position_list_max_size(self, limit=256):
         """
@@ -1136,7 +1136,7 @@ class Database:
         :param limit:Max position containing list size
         :return:The database object
         """
-        self.config[u'positions-list-max-size'] = limit
+        self.config['positions-list-max-size'] = limit
         return self
 
     def position_list_max_size(self):
@@ -1145,9 +1145,9 @@ class Database:
 
         :return:The maximum position containing list size
         """
-        return self.config[u'positions-list-max-size']
+        return self.config['positions-list-max-size']
 
-    def set_format_compatibility(self, which=u'automatic'):
+    def set_format_compatibility(self, which='automatic'):
         """
         Version of on-disk forest format.
 
@@ -1155,7 +1155,7 @@ class Database:
         :return:The database object
         """
         validate_format_compatibility_options(which)
-        self.config[u'format-compatibility'] = which
+        self.config['format-compatibility'] = which
         return self
 
     def format_compatibility(self):
@@ -1164,9 +1164,9 @@ class Database:
 
         :return:The on-disk forest format
         """
-        return self.config[u'format-compatibility']
+        return self.config['format-compatibility']
 
-    def set_index_detection(self, which=u'automatic'):
+    def set_index_detection(self, which='automatic'):
         """
         Handling of differences between the current configuration of database indexes and on-disk settings.
 
@@ -1174,7 +1174,7 @@ class Database:
         :return:The database object
         """
         validate_index_detection_options(which)
-        self.config[u'index-detection'] = which
+        self.config['index-detection'] = which
         return self
 
     def index_detection(self):
@@ -1183,9 +1183,9 @@ class Database:
 
         :return:How to handle differences in configuration settings
         """
-        return self.config[u'index-detection']
+        return self.config['index-detection']
 
-    def set_expunge_locks(self, which=u'none'):
+    def set_expunge_locks(self, which='none'):
         """
         Garbage collection of timed locks that have expired.
 
@@ -1193,7 +1193,7 @@ class Database:
         :return:The database object
         """
         validate_expunge_locks_options(which)
-        self.config[u'expunge-locks'] = which
+        self.config['expunge-locks'] = which
         return self
 
     def expunge_locks(self):
@@ -1202,9 +1202,9 @@ class Database:
 
         :return:How to garbage collect timed locks
         """
-        return self.config[u'expunge-locks']
+        return self.config['expunge-locks']
 
-    def set_if_normalization(self, which=u'scaled-log'):
+    def set_if_normalization(self, which='scaled-log'):
         """
         What kind of term frequency normalization to apply.
 
@@ -1212,7 +1212,7 @@ class Database:
         :return:The database object
         """
         validate_term_frequency_normalization_options(which)
-        self.config[u'tf-normalization'] = which
+        self.config['tf-normalization'] = which
         return self
 
     def if_normalization(self):
@@ -1221,9 +1221,9 @@ class Database:
 
         :return:The term frequency normalization option
         """
-        return self.config[u'tf-normalization']
+        return self.config['tf-normalization']
 
-    def set_merge_priority(self, which=u'lower'):
+    def set_merge_priority(self, which='lower'):
         """
         The CPU scheduler priority for merges.
 
@@ -1231,7 +1231,7 @@ class Database:
         :return:The database object
         """
         validate_merge_priority_options(which)
-        self.config[u'merge-priority'] = which
+        self.config['merge-priority'] = which
         return self
 
     def merge_priority(self):
@@ -1240,7 +1240,7 @@ class Database:
 
         :return:CPU scheduling hint for merges
         """
-        return self.config[u'merge-priority']
+        return self.config['merge-priority']
 
     def set_merge_max_size(self, limit=32768):
         """
@@ -1249,11 +1249,11 @@ class Database:
         :param limit:Size in megabytes
         :return:The database object
         """
-        self.config[u'merge-max-size'] = limit
+        self.config['merge-max-size'] = limit
         return self
 
     def merge_max_size(self):
-        return self.config[u'merge-max-size']
+        return self.config['merge-max-size']
 
     def set_merge_min_size(self, limit=1024):
         """
@@ -1262,7 +1262,7 @@ class Database:
         :param limit:Minimum stand count for merge
         :return:The database object
         """
-        self.config[u'merge-min-size'] = limit
+        self.config['merge-min-size'] = limit
         return self
 
     def merge_min_size(self):
@@ -1271,7 +1271,7 @@ class Database:
 
         :return:Minimum stand count for merge
         """
-        return self.config[u'merge-min-size']
+        return self.config['merge-min-size']
 
     def set_merge_min_ratio(self, limit=2):
         """
@@ -1280,7 +1280,7 @@ class Database:
         :param limit: The marge min ratio
         :return:The database object
         """
-        self.config[u'merge-min-ratio'] = limit
+        self.config['merge-min-ratio'] = limit
         return self
 
     def merge_min_ratio(self):
@@ -1289,7 +1289,7 @@ class Database:
 
         :return:The marge min ratio
         """
-        return self.config[u'merge-min-ratio']
+        return self.config['merge-min-ratio']
 
     def set_merge_timestamp(self, limit=0):
         """
@@ -1298,7 +1298,7 @@ class Database:
         :param limit:Minimum value
         :return:The database object
         """
-        self.config[u'merge-timestamp'] = limit
+        self.config['merge-timestamp'] = limit
         return self
 
     def merge_timestamp(self):
@@ -1307,10 +1307,10 @@ class Database:
 
         :return:Minimum value
         """
-        return self.config[u'merge-timestamp']
+        return self.config['merge-timestamp']
 
     def set_retain_until_backup(self, enabled=False):
-        self.config[u'retain-until-backup'] = enabled
+        self.config['retain-until-backup'] = enabled
         return self
 
     def set_rebalancer_enable(self, enabled=True):
@@ -1321,7 +1321,7 @@ class Database:
         :return:The database object
         """
         validate_boolean(enabled)
-        self.config[u'rebalancer-enable'] = enabled
+        self.config['rebalancer-enable'] = enabled
         return self
 
     def rebalancer_enable(self):
@@ -1330,7 +1330,7 @@ class Database:
 
         :return:Enable automatic rebalancing
         """
-        return self.config[u'rebalancer-enable']
+        return self.config['rebalancer-enable']
 
     def set_rebalancer_throttle(self, limit=5):
         """
@@ -1340,7 +1340,7 @@ class Database:
         :return:The database object
         """
         validate_integer_range(limit, 1, 5)
-        self.config[u'rebalancer-throttle'] = limit
+        self.config['rebalancer-throttle'] = limit
         return self
 
     def rebalancer_throttle(self):
@@ -1349,9 +1349,9 @@ class Database:
 
         :return:The relative amount of resources to dedicate to rebalancing
         """
-        return self.config[u'rebalancer-throttle']
+        return self.config['rebalancer-throttle']
 
-    def set_assignemnt_policy(self, which=u'bucket'):
+    def set_assignemnt_policy(self, which='bucket'):
         """
         What policy to use for assignment and rebalancing.
 
@@ -1359,7 +1359,7 @@ class Database:
         :return:The database object
         """
         validate_assignment_policy_options(which)
-        self.config[u'assignment-policy'] = {"assignment-policy-name": which}
+        self.config['assignment-policy'] = {"assignment-policy-name": which}
         return self
 
     def assignment_policy(self):
@@ -1368,7 +1368,7 @@ class Database:
 
         :return:The policy for assignment and rebalancing
         """
-        return self.config[u'assignment-policy']
+        return self.config['assignment-policy']
 
     def add_path_namespace(self, prefix, namespace):
         """
@@ -1378,12 +1378,12 @@ class Database:
         :param namespace: The namespace uri (i.e. 'http://bar.com')
         :return: The database object
         """
-        if u'path-namespaces' not in self.config:
-            self.config[u'path-namespaces'] = []
+        if 'path-namespaces' not in self.config:
+            self.config['path-namespaces'] = []
 
-        self.config[u'path-namespaces'].append({
-            u'prefix': prefix,
-            u'namespace-uri': namespace
+        self.config['path-namespaces'].append({
+            'prefix': prefix,
+            'namespace-uri': namespace
         })
         return self
 
@@ -1394,9 +1394,9 @@ class Database:
 
         :return:The path namespaces or none
         """
-        if u'path-namespaces' not in self.config:
+        if 'path-namespaces' not in self.config:
             return None
-        return self.config[u'path-namespaces']
+        return self.config['path-namespaces']
 
     def create(self, connection):
         """
@@ -1407,11 +1407,18 @@ class Database:
         """
         uri = "http://{0}:{1}/manage/v2/databases".format(connection.host, connection.management_port)
 
-        for forest_name in self.config[u'forest']:
-            new_forest = Forest(forest_name)
-            if self.hostname is not None:
-                new_forest.set_host(self.hostname)
-            new_forest.create(connection)
+        forest_names = []
+        for forest_info in self.config['forest']:
+            if isinstance(forest_info, str) or isinstance(forest_info, unicode):
+                new_forest = Forest(forest_info, host=self.hostname)
+                new_forest.create(connection)
+                forest_names.append(forest_info)
+
+            elif isinstance(forest_info, Forest):
+                forest_info.create(connection)
+                forest_names.append(forest_info.name())
+
+        self.config['forest'] = forest_names
 
         response = requests.post(uri, json=self.config, auth=connection.auth)
         if response.status_code > 299:
@@ -1428,7 +1435,7 @@ class Database:
         :return:The database object
         """
         uri = "http://{0}:{1}/manage/v2/databases/{2}/properties".format(connection.host, connection.management_port,
-                                                                         self.config[u'database-name'])
+                                                                         self.config['database-name'])
         response = requests.put(uri, json=self.config, auth=connection.auth)
 
         if response.status_code > 299:
@@ -1444,19 +1451,20 @@ class Database:
         :return:The database object
         """
         uri = "http://{0}:{1}/manage/v2/databases/{2}".format(connection.host, connection.management_port,
-                                                              self.config[u'database-name'])
+                                                              self.config['database-name'])
         response = requests.delete(uri, auth=connection.auth)
 
         if response.status_code > 299 and not response.status_code == 404:
             raise UnexpectedManagementAPIResponse(response.text)
 
-        for forest_name in self.config[u'forest']:
-            forest_uri = uri = "http://{0}:{1}/manage/v2/forests/{2}?level=full".format(connection.host,
-                                                                                        connection.management_port,
-                                                                                        forest_name)
-            response = requests.delete(forest_uri, auth=connection.auth)
-            if response.status_code > 299 and not response.status_code == 404:
-                raise UnexpectedManagementAPIResponse(response.text)
+        if 'forest' in self.config:
+            for forest_name in self.config['forest']:
+                forest_uri = uri = "http://{0}:{1}/manage/v2/forests/{2}?level=full".format(connection.host,
+                                                                                            connection.management_port,
+                                                                                            forest_name)
+                response = requests.delete(forest_uri, auth=connection.auth)
+                if response.status_code > 299 and not response.status_code == 404:
+                    raise UnexpectedManagementAPIResponse(response.text)
 
         return self
 
@@ -1472,7 +1480,7 @@ class Database:
         :return:The database object
         """
         doc_url = "http://{0}:{1}/v1/documents?uri={2}&database={3}".format(connection.host, connection.port, uri,
-                                                                            self.config[u'database-name'])
+                                                                            self.config['database-name'])
 
         if collections is not None:
             for collection in collections:
@@ -1535,7 +1543,7 @@ class Database:
         """
         uri = "http://{0}:{1}/manage/v2/databases/{2}/properties".format(connection.host, connection.management_port,
                                                                          name)
-        response = requests.get(uri, auth=connection.auth, headers={u'accept': u'application/json'})
+        response = requests.get(uri, auth=connection.auth, headers={'accept': 'application/json'})
 
         result = None
         if response.status_code == 200:
@@ -1575,11 +1583,11 @@ class Database:
         """
         index_name = "range-element-index"
         if index_def.__class__ == ElementRange:
-            index_name = u'range-element-index'
+            index_name = 'range-element-index'
         elif index_def.__class__ == ElementAttributeRange:
-            index_name = u'range-element-attribute-index'
+            index_name = 'range-element-attribute-index'
         elif index_def.__class__ == FieldRange:
-            index_name = u'range-field-index'
+            index_name = 'range-field-index'
 
         if index_name not in self.config:
             self.config[index_name] = []
@@ -1588,37 +1596,37 @@ class Database:
         return self
 
     def field_range_index(self, index=None):
-        if index is None and u'range-field-index' in self.config:
+        if index is None and 'range-field-index' in self.config:
             result = []
-            for field in self.config[u'range-field-index']:
+            for field in self.config['range-field-index']:
                 temp = FieldRange("", "")
                 temp.config = field
                 result.append(temp)
             return result
-        elif u'range-field-index' in self.config and len(self.config[u'range-field-index']) > index:
+        elif 'range-field-index' in self.config and len(self.config['range-field-index']) > index:
             temp = FieldRange("", "")
-            temp.config = self.config[u'range-field-index'][index]
+            temp.config = self.config['range-field-index'][index]
             return temp
         return None
 
     def add_field(self, field):
-        if u'field' not in self.config:
-            self.config[u'field'] = []
+        if 'field' not in self.config:
+            self.config['field'] = []
 
-        self.config[u'field'].append(field.config)
+        self.config['field'].append(field.config)
 
         return self
 
     def fields(self, field_idx):
-        if u'fields' not in self.config:
+        if 'fields' not in self.config:
             return None
-        if field_idx >= len(self.config[u'fields']):
+        if field_idx >= len(self.config['fields']):
             return None
-        return self.config[u'fields'][field_idx]
+        return self.config['fields'][field_idx]
 
     def get_document(self, conn, document_uri, content_type='*/*'):
         doc_url = "http://{0}:{1}/v1/documents?uri={2}&database={3}".format(conn.host, conn.port, document_uri,
-                                                                            self.config[u'database-name'])
+                                                                            self.config['database-name'])
 
         response = requests.get(doc_url, auth=conn.auth, headers={'accept': content_type})
         if response.status_code == 404:

--- a/marklogic/models/database.py
+++ b/marklogic/models/database.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, absolute_import
+
 #
 # Copyright 2015 MarkLogic Corporation
 #
@@ -1542,6 +1545,25 @@ class Database:
             raise UnexpectedManagementAPIResponse(response.text)
 
         return result
+
+    @classmethod
+    def list_databases(cls, connection):
+        uri = "http://{0}:{1}/manage/v2/databases".format(connection.host, connection.management_port)
+        response = requests.get(uri, auth=connection.auth, headers={'accept': 'application/json'})
+
+        if response.status_code == 200:
+            response_json = json.loads(response.text)
+            db_count = response_json['database-default-list']['list-items']['list-count']['value']
+
+            result = []
+            if db_count > 0:
+                for item in response_json['database-default-list']['list-items']['list-item']:
+                    result.append(Database.lookup(item['nameref'], connection))
+        else:
+            raise UnexpectedManagementAPIResponse(response.text)
+
+        return result
+
 
     def add_index(self, index_def):
         """

--- a/marklogic/models/forest.py
+++ b/marklogic/models/forest.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, absolute_import
+
 #
 # Copyright 2015 MarkLogic Corporation
 #
@@ -22,6 +25,7 @@
 import socket
 import requests
 import json
+from .utilities.validators import validate_forest_availability
 
 """
 MarkLogic Forest support classes.
@@ -48,6 +52,14 @@ class Forest:
         self.config[u'host'] = host
         return self
 
+    def host(self):
+        """
+        Return the hostname for this forest
+
+        :return: The hostname
+        """
+        return self.config['host']
+
     def set_database(self, db='Documents'):
         """
         The database to which this forest belongs.
@@ -55,8 +67,16 @@ class Forest:
         :param db: A database name
         :return: The Forest object
         """
-        self.config[u'database'] = db
+        self.config['database'] = db
         return self
+
+    def database(self):
+        """
+        Return the database for the forest
+
+        :return: The asociated database
+        """
+        return self.config['database']
 
     def set_data_directory(self, datadir='/var/opt/MarkLogic/Data'):
         """
@@ -66,8 +86,16 @@ class Forest:
         :param datadir: The forest's data directory
         :return: The Forest object
         """
-        self.config[u'data-directory'] = datadir
+        self.config['data-directory'] = datadir
         return self
+
+    def data_directory(self):
+        """
+        Returns the data directory for the forest.
+
+        :return: The data directory path
+        """
+        return self.config['data-directory']
 
     def set_large_data_directory(self, datadir='/var/opt/MarkLogic/Big_Data'):
         """
@@ -77,8 +105,16 @@ class Forest:
         :param datadir: The forest's large data directory
         :return: The Forest object
         """
-        self.config[u'large-data-directory'] = datadir
+        self.config['large-data-directory'] = datadir
         return self
+
+    def large_data_directory(self):
+        """
+        Return the large data directory for the forest
+
+        :return:The large data directory path
+        """
+        return self.config['large-data-directory']
 
     def set_fast_data_directory(self, datadir='/var/opt/MarkLogic/Fast_Data'):
         """
@@ -88,8 +124,16 @@ class Forest:
         :param datadir: The forest's fast data directory
         :return: The Forest object
         """
-        self.config[u'fast-data-directory'] = datadir
+        self.config['fast-data-directory'] = datadir
         return self
+
+    def fast_data_directory(self):
+        """
+        Return the fast data directory for the forest.
+
+        :return:The fast data directory
+        """
+        return self.config['fast-data-directory']
 
     def set_availability(self, which='online'):
         """
@@ -98,8 +142,17 @@ class Forest:
         :param which: The availability of the forest
         :return: The Forest object
         """
-        self.config[u'availability'] = which
+        validate_forest_availability(which)
+        self.config['availability'] = which
         return self
+
+    def availability(self):
+        """
+        Returns the availability status for the forest.
+
+        :return: Availability status
+        """
+        return self.config[u'availability']
 
     def name(self):
         """

--- a/marklogic/models/host.py
+++ b/marklogic/models/host.py
@@ -24,6 +24,7 @@ from __future__ import unicode_literals, print_function, absolute_import
 
 import requests
 import json
+from .utilities.exceptions import *
 
 
 class Host(object):
@@ -94,7 +95,7 @@ class Host(object):
             result = Host()
             result.config = json.loads(response.text)
         elif response.status_code != 404:
-            raise Exception(response)
+            raise UnexpectedManagementAPIResponse(response.text)
         return result
 
     @classmethod
@@ -117,6 +118,6 @@ class Host(object):
                 for item in response_json['host-default-list']['list-items']['list-item']:
                     result.append(Host.lookup(item['nameref'], connection))
         else:
-            raise Exception(response)
+            raise UnexpectedManagementAPIResponse(response.text)
 
         return result

--- a/marklogic/models/utilities/validators.py
+++ b/marklogic/models/utilities/validators.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, absolute_import
+
 #
 # Copyright 2015 MarkLogic Corporation
 #
@@ -114,3 +117,8 @@ def validate_assignment_policy_options(raw_val):
 
 def validate_custom(message):
     raise ValidationError("Validation error", repr(message))
+
+
+def validate_forest_availability(raw_val):
+    if raw_val not in ['online', 'offline']:
+        raise ValidationError("Forest availability status is not a valid value", repr(raw_val))

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, absolute_import
+
+#
+# Copyright 2015 MarkLogic Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0#
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# File History
+# ------------
+#
+# Paul Hoehne       03/28/2015     Initial development
+#
+
+"""
+Edit this file to create test settings applicable to your system.
+
+"""
+
+class DatabaseSettings(object):
+    large_data_directory = "/data/large"
+    fast_data_directory = "/data/fast"
+

--- a/tests/databases/test_database.py
+++ b/tests/databases/test_database.py
@@ -66,3 +66,13 @@ class TestDatabase(unittest.TestCase):
         db = Database.lookup("No-Such-Database", conn)
 
         self.assertIsNone(db)
+
+    def test_list_databases(self):
+        conn = Connection(tc.hostname, HTTPDigestAuth(tc.admin, tc.password))
+        databases = Database.list_databases(conn)
+
+        self.assertGreater(len(databases), 4)
+
+        db_names = [db.database_name() for db in databases]
+        self.assertTrue("Modules" in db_names)
+        self.assertTrue("Documents" in db_names)

--- a/tests/databases/test_database.py
+++ b/tests/databases/test_database.py
@@ -24,7 +24,6 @@ from __future__ import unicode_literals, print_function, absolute_import
 #
 
 import unittest
-import os
 from marklogic.models import Database, Connection, Host
 from requests.auth import HTTPDigestAuth
 from resources import TestConnection as tc

--- a/tests/databases/test_forest.py
+++ b/tests/databases/test_forest.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, absolute_import
+
+#
+# Copyright 2015 MarkLogic Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0#
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# File History
+# ------------
+#
+# Paul Hoehne       03/28/2015     Initial development
+#
+
+import unittest
+from marklogic.models import Forest
+from marklogic.models.utilities.validators import ValidationError
+
+class TestForest(unittest.TestCase):
+    def test_forest_defaults(self):
+        pass
+
+    def test_getters_and_setters(self):
+        forest = Forest("Foo")
+
+        self.assertEqual(forest.name(), "Foo")
+
+        forest.set_availability("offline")
+        self.assertEqual("offline", forest.availability())
+
+        with self.assertRaises(ValidationError):
+            forest.set_availability("foo")
+
+        forest.set_host("bar")
+        self.assertEqual("bar", forest.host())
+
+        forest.set_data_directory("/foo/bar")
+        self.assertEqual("/foo/bar", forest.data_directory())
+
+        forest.set_database("foo")
+        self.assertEqual("foo", forest.database())
+
+        forest.set_fast_data_directory("/foo/bar")
+        self.assertEqual("/foo/bar", forest.fast_data_directory())
+
+        forest.set_large_data_directory("/foo/bar")
+        self.assertEqual("/foo/bar", forest.large_data_directory())

--- a/tests/databases/test_forest.py
+++ b/tests/databases/test_forest.py
@@ -23,15 +23,19 @@ from __future__ import unicode_literals, print_function, absolute_import
 #
 
 import unittest
-from marklogic.models import Forest
+from marklogic.models import Forest, Host, Connection
+from resources import TestConnection as tc
+from requests.auth import HTTPDigestAuth
 from marklogic.models.utilities.validators import ValidationError
+from test_settings import DatabaseSettings as ds
 
 class TestForest(unittest.TestCase):
     def test_forest_defaults(self):
         pass
 
     def test_getters_and_setters(self):
-        forest = Forest("Foo")
+        forest = Forest("Foo", host="bar", data_directory="/foo/bar", large_data_directory="/foo/bar",
+                        fast_data_directory="/foo/bar")
 
         self.assertEqual(forest.name(), "Foo")
 
@@ -41,17 +45,34 @@ class TestForest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             forest.set_availability("foo")
 
-        forest.set_host("bar")
         self.assertEqual("bar", forest.host())
 
-        forest.set_data_directory("/foo/bar")
         self.assertEqual("/foo/bar", forest.data_directory())
 
         forest.set_database("foo")
         self.assertEqual("foo", forest.database())
 
-        forest.set_fast_data_directory("/foo/bar")
         self.assertEqual("/foo/bar", forest.fast_data_directory())
 
-        forest.set_large_data_directory("/foo/bar")
         self.assertEqual("/foo/bar", forest.large_data_directory())
+
+    def test_create_forest(self):
+        conn = Connection(tc.hostname, HTTPDigestAuth(tc.admin, tc.password))
+
+        host = Host.list_hosts(conn)[0]
+
+        forest = Forest("test-forest-simple-create", host=host.host_name(),
+                        large_data_directory=ds.large_data_directory,
+                        fast_data_directory=ds.fast_data_directory, )
+        forest.create(conn)
+
+        forest = Forest.lookup("test-forest-simple-create", conn)
+
+        try:
+            self.assertIsNotNone(forest)
+            self.assertEqual("test-forest-simple-create", forest.name())
+            self.assertEqual(host.host_name(), forest.host())
+            self.assertEqual(ds.large_data_directory, forest.large_data_directory())
+            self.assertEqual(ds.fast_data_directory, forest.fast_data_directory())
+        finally:
+            forest.remove(conn)


### PR DESCRIPTION
There were problems when creating forests by adding an array of Forests which had properties configured on those forests.  (If you don't care about setting forest properties, you can just set the forests on the server as a list of strings and they'll get the default configuration).  You can pass an array of Forest objects to set_forests on database.  In that case, what should happen, is that forests are created with the properties on the forest object.  Some, like availability, are changeable.  Others, like the large data dictionary, cannot be changed after the forest is created.