### PR TITLE
Fixed MLCP test typos and design.

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -24,6 +24,8 @@ from __future__ import unicode_literals, print_function, absolute_import
 
 """
 Edit this file to create test settings applicable to your system.
+The string must represent a complete path to an existing directory on the server.
+You will find the current root data directory on the ML Admin Forests Summary page. 
 
 """
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -28,6 +28,6 @@ Edit this file to create test settings applicable to your system.
 """
 
 class DatabaseSettings(object):
-    large_data_directory = "/data/large"
-    fast_data_directory = "/data/fast"
+    large_data_directory = ""
+    fast_data_directory = ""
 

--- a/tests/tools/test_mlcp_download.py
+++ b/tests/tools/test_mlcp_download.py
@@ -26,6 +26,7 @@ from marklogic.tools import MLCPLoader
 from marklogic.models import Connection
 from marklogic.recipes import SimpleDatabase
 from requests.auth import HTTPDigestAuth
+from resources import TestConnection as tc
 
 class TestMLCPDownload(unittest.TestCase):
 
@@ -50,10 +51,12 @@ class TestMLCPDownload(unittest.TestCase):
         self.assertFalse(os.path.isdir(".mlcp"))
 
     def test_load_data(self):
-        simpledb = SimpleDatabase("exmaple_app", port=8400)
+        simpledb = SimpleDatabase("example_app", port=8400)
 
-        auth = HTTPDigestAuth("admin", "admin")
-        conn = Connection("192.168.57.141", auth)
+        conn = Connection(tc.hostname, HTTPDigestAuth(tc.admin, tc.password))
+
+##        auth = HTTPDigestAuth("admin", "admin")
+##        conn = Connection("192.168.1.11", auth)
 
         exampledb = simpledb.create(conn)
 
@@ -73,3 +76,6 @@ class TestMLCPDownload(unittest.TestCase):
 
             exampledb[u'modules'].remove(conn)
             exampledb[u'content'].remove(conn)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Changed default test_setting.py values to use an empty directory. 

Changed test_mlcp_download.py to use resources.py insead of hardcoding IPAddr and credentials.

Fixed typo in test_mlcp_download.py
